### PR TITLE
Match the main documentation page with the membership README

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,46 @@
 # Django Commons
 
-## Repositories
+Django Commons is an organization dedicated to supporting the community's efforts to maintain packages. It seeks to improve the maintenance experience for all contributors; reducing the barrier to entry for new contributors and reducing overhead for existing maintainers.
 
-- [django-commons/membership](https://github.com/django-commons/membership)
-- [django-commons/best-practices](https://github.com/django-commons/best-practices)
-- [django-commons/controls](https://github.com/django-commons/controls)
+Django Commons has lofty goals for the future, but it will only be possible with your help:
+
+- Identify and announce packages needing help
+- Normalize and support maintainers periodically stepping back
+- Support and encourage new contributors to step up
+- Provide best practices for package maintainers
+- Compensate maintainers
+
+## How to join as a contributor?
+
+1. Review [Code of Conduct](https://github.com/django-commons/membership/blob/main/CODE_OF_CONDUCT.md)
+2. Create a [new member issue in the django-commons/membership repository](https://github.com/django-commons/membership/issues/new/choose).
+
+## How to transfer a project in?
+
+1. A person with the ability to transfer the project must join Django Commons (see [How to join as a contributor?](https://github.com/django-commons/membership#how-to-join-as-a-contributor))
+2. Create a [transfer project in issue in the django-commons/membership repository](https://github.com/django-commons/membership/issues/new/choose).
+
+## How to transfer a project out?
+
+1. Create a [transfer project out issue in the django-commons/membership repository](https://github.com/django-commons/membership/issues/new/choose).
+
+## Projects
+
+The following projects are maintained by the Django Commons community:
+
+- [django-click](https://github.com/django-commons/django-click): Write Django management command using the click CLI library
+- [django-debug-toolbar](https://github.com/django-commons/django-debug-toolbar): A configurable set of panels that display various debug information about the current request/response.
+- [django-enum](https://github.com/django-commons/django-enum): Full and natural support for enumerations as Django model fields.
+- [drf-excel](https://github.com/django-commons/drf-excel): An XLSX spreadsheet renderer for Django REST Framework.
+- [django-fsm-2](https://github.com/django-commons/django-fsm-2): Django friendly finite state machine support
+- [django-tailwind-cli](https://github.com/django-commons/django-tailwind-cli): Django and Tailwind integration based on the prebuilt Tailwind CSS CLI.
+- [django-tasks-scheduler](https://github.com/django-commons/django-tasks-scheduler): Schedule async tasks using redis protocol. Redis/ValKey/Dragonfly or any broker using the redis protocol can be used.
+- [django-typer](https://github.com/django-commons/django-typer): Use Typer (type hints) to define the interface for your Django management commands.
+
+### Internal projects
+
+The following repositories are internal to Django Commons and are not actual libraries:
+
+- [django-commons/membership](https://github.com/django-commons/membership): Membership repository for the django-commons organization.
+- [django-commons/best-practices](https://github.com/django-commons/best-practices): A sample project with best practices for Django Commons projects.
+- [django-commons/controls](https://github.com/django-commons/controls): The controls for managing Django Commons projects


### PR DESCRIPTION
The FAQ and content sections will be broken off into separate pages.

Refs #9 